### PR TITLE
Add Obsidian Sync CLI agent post + legacy post update note

### DIFF
--- a/src/content/blog/deploying-obsidian-sync-for-my-ai-agents.md
+++ b/src/content/blog/deploying-obsidian-sync-for-my-ai-agents.md
@@ -1,0 +1,130 @@
+---
+title: Deploying Obsidian Sync for My AI Agents
+description: >-
+  I set up Obsidian Sync for AI agents in a terminal-only Ubuntu Server
+  environment using the official CLI and a continuous systemd service, then
+  retired my old GUI workaround.
+pubDate: '2026-03-03'
+tags:
+  - obsidian
+  - sync
+  - cli
+  - ai
+  - agents
+  - openclaw
+  - homelab
+  - blog
+category: tech
+---
+
+I wanted my AI agents to work directly against my Obsidian vault without babysitting a desktop app.
+
+Now that Obsidian has an official sync client, this is finally clean to run on Linux.
+
+This post is the agent-focused setup I’m using today.
+
+## This is not just a Linux tweak
+
+The core issue for me was environment, not preference.
+
+I run Ubuntu Server in a terminal-only setup with no GUI at all. I don’t want a fake desktop stack just to keep note sync alive. The official Obsidian Sync CLI is what finally made this implementation both minimal and complete for my use case. I'm also lazy and this method is extremely straightforward to set up.
+
+If you want the old workaround (Xvfb + Openbox + desktop Obsidian), I documented that in my previous post:
+[Headless Obsidian Sync on Linux (No GUI Required)](/blog/headless-obsidian-sync-on-linux/)
+
+## Why this matters for agent workflows
+
+For something like OpenClaw (or any agent stack), this is a big deal:
+- no fake GUI session
+- fewer moving parts
+- easier to run as infrastructure
+- easier to monitor/restart with systemd
+
+My agents get a synced local vault path, and I get fewer things to break.
+
+## What I installed
+
+I installed Obsidian’s sync client (`ob`) and logged in.
+
+Then I linked my local vault path:
+- `/path/to/your-vault`
+
+Quick checks I run:
+
+```bash
+ob login
+ob sync-list-local
+ob sync-list-remote
+ob sync-status --path /path/to/your-vault
+```
+
+## Continuous sync setup (the important part)
+
+Quick clarification: `ob sync --continuous` is only continuous while that process is alive. It does not magically persist across reboot, and it dies with your shell/session if unmanaged.
+
+If you want this to survive agent restarts, shell exits, and server reboots, run it as a systemd service.
+
+I run this as a user service:
+
+```bash
+ob sync --path /path/to/your-vault --continuous
+```
+
+### systemd unit
+
+`~/.config/systemd/user/obsidian-continuous-sync.service`
+
+```ini
+[Unit]
+Description=Obsidian Continuous Sync
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/env ob sync --path /path/to/your-vault --continuous
+Restart=always
+RestartSec=5
+WorkingDirectory=%h
+
+[Install]
+WantedBy=default.target
+```
+
+Enable it:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now obsidian-continuous-sync.service
+systemctl --user status obsidian-continuous-sync.service
+```
+
+## Quick sanity check
+
+If you want a fast confidence check, run:
+
+```bash
+ob sync-status --path /path/to/your-vault
+systemctl --user status obsidian-continuous-sync.service
+```
+
+You’re looking for a healthy sync config and an active service.
+
+## I did migrate from the old method
+
+I migrated from my previous GUI workaround stack:
+- Xvfb
+- Openbox
+- Obsidian desktop app
+- helper services for all of the above
+
+That method worked, but this one is cleaner and more reliable for agent infrastructure. It also helps that this is the official path now.
+
+## Final take
+
+If your goal is “Obsidian for agents,” this is the model I recommend now:
+- official Obsidian Sync CLI
+- continuous sync service
+- one stable vault path for your automations
+
+That’s it. Set it once, let it run.

--- a/src/content/blog/headless-obsidian-sync-on-linux.md
+++ b/src/content/blog/headless-obsidian-sync-on-linux.md
@@ -1,8 +1,3 @@
-> [!IMPORTANT]
-> **Update (2026-03-03):** Obsidian now has an official sync CLI path.
-> I now recommend this setup for agent workflows:
-> [Deploying Obsidian Sync for My AI Agents](/blog/deploying-obsidian-sync-for-my-ai-agents/).
-
 ---
 title: Headless Obsidian Sync on Linux (No GUI Required)
 description: >-
@@ -15,6 +10,12 @@ tags:
   - homelab
 category: tech
 ---
+
+> [!IMPORTANT]
+> **Update (2026-03-03):** Obsidian now has an official sync CLI path.
+> I now recommend this setup for agent workflows:
+> [Deploying Obsidian Sync for My AI Agents](/blog/deploying-obsidian-sync-for-my-ai-agents/).
+
 Obsidian Sync is great — but it assumes you're sitting at a computer with a screen. What if you want your vault synced on a headless Linux server? Maybe an AI agent needs access, maybe you want a centralized backup, or maybe you just want your notes available on a machine with no monitor.
 
 Here's how to run Obsidian with native Sync on a headless Linux VM.

--- a/src/content/blog/headless-obsidian-sync-on-linux.md
+++ b/src/content/blog/headless-obsidian-sync-on-linux.md
@@ -1,3 +1,5 @@
+> **Update (2026-03-03):** Obsidian now has an official sync CLI. > I published my current recommended setup for agent workflows here: > [Deploying Obsidian Sync for My AI Agents](/blog/deploying-obsidian-sync-for-my-ai-agents/).
+
 ---
 title: Headless Obsidian Sync on Linux (No GUI Required)
 description: >-

--- a/src/content/blog/headless-obsidian-sync-on-linux.md
+++ b/src/content/blog/headless-obsidian-sync-on-linux.md
@@ -1,4 +1,7 @@
-> **Update (2026-03-03):** Obsidian now has an official sync CLI. > I published my current recommended setup for agent workflows here: > [Deploying Obsidian Sync for My AI Agents](/blog/deploying-obsidian-sync-for-my-ai-agents/).
+> [!IMPORTANT]
+> **Update (2026-03-03):** Obsidian now has an official sync CLI path.
+> I now recommend this setup for agent workflows:
+> [Deploying Obsidian Sync for My AI Agents](/blog/deploying-obsidian-sync-for-my-ai-agents/).
 
 ---
 title: Headless Obsidian Sync on Linux (No GUI Required)


### PR DESCRIPTION
## Summary
- add new post: **Deploying Obsidian Sync for My AI Agents**
- add top-of-post update note to legacy headless workaround article

## Why
- Obsidian now has an official sync CLI path
- readers landing on the legacy workaround should be directed to the current supported method

## Notes
- update note text is intentionally concise so it can be reviewed/tweaked easily
